### PR TITLE
Fix code scanning alert no. 22: Flask app is run in debug mode

### DIFF
--- a/nginx-wsgi-flask/flask/wsgi.py
+++ b/nginx-wsgi-flask/flask/wsgi.py
@@ -2,4 +2,5 @@ from app import app
 import os
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=os.environ.get("FLASK_SERVER_PORT"), debug=True)
+    debug_mode = os.environ.get("FLASK_DEBUG", "False").lower() in ["true", "1", "t"]
+    app.run(host='0.0.0.0', port=os.environ.get("FLASK_SERVER_PORT"), debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/aka2024/studious-fiesta/security/code-scanning/22](https://github.com/aka2024/studious-fiesta/security/code-scanning/22)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable to control the debug mode. We will modify the code to check the environment variable `FLASK_DEBUG` and set the `debug` parameter accordingly.

- Modify the `app.run` call to set the `debug` parameter based on the `FLASK_DEBUG` environment variable.
- Ensure that the default value for `FLASK_DEBUG` is `False` if the environment variable is not set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
