### PR TITLE
Fix code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/react-express-mysql/backend/package.json
+++ b/react-express-mysql/backend/package.json
@@ -17,7 +17,8 @@
     "express": "^4.17.1",
     "knex": "^0.95.11",
     "morgan": "^1.10.0",
-    "mysql2": "^2.1.0"
+    "mysql2": "^2.1.0",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/react-express-mysql/backend/src/server.js
+++ b/react-express-mysql/backend/src/server.js
@@ -2,6 +2,7 @@
 // optimized for Docker image
 
 const express = require("express");
+const RateLimit = require("express-rate-limit");
 // this example uses express web framework so we know what longer build times
 // do and how Dockerfile layer ordering matters. If you mess up Dockerfile ordering
 // you'll see long build times on every code change + build. If done correctly,
@@ -17,9 +18,15 @@ const database = require("./database");
 // Appi
 const app = express();
 
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 app.use(morgan("common"));
 
-app.get("/", function(req, res, next) {
+app.get("/", limiter, function(req, res, next) {
   database.raw('select VERSION() version')
     .then(([rows, columns]) => rows[0])
     .then((row) => res.json({ message: `Hello from MySQL ${row.version}` }))


### PR DESCRIPTION
Fixes [https://github.com/aka2024/studious-fiesta/security/code-scanning/6](https://github.com/aka2024/studious-fiesta/security/code-scanning/6)

To fix the problem, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests a client can make to the server within a specified time window. Specifically, we will:
1. Install the `express-rate-limit` package.
2. Set up a rate limiter with a reasonable configuration (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter to the routes that perform expensive operations, such as database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
